### PR TITLE
Lint fixes

### DIFF
--- a/drr.go
+++ b/drr.go
@@ -4,20 +4,20 @@ package drr
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 )
 
 var (
-	// InvalidPriorityValueError error is returned by Input method when
+	// ErrInvalidPriorityValueError error is returned by Input method when
 	// priority value is less than or equal to 0.
-	InvalidPriorityValueError = fmt.Errorf("InvalidPriorityValueError")
-	// ChannelIsNilError error is returned by NewDRR and Input methods
+	ErrInvalidPriorityValueError = errors.New("ErrInvalidPriorityValueError")
+	// ErrChannelIsNilError error is returned by NewDRR and Input methods
 	// when channel is nil.
-	ChannelIsNilError = fmt.Errorf("ChannelIsNilError")
-	// ContextIsNilError is returned by Start method when context.Context
+	ErrChannelIsNilError = errors.New("ErrChannelIsNilError")
+	// ErrContextIsNilError is returned by Start method when context.Context
 	// is nil
-	ContextIsNilError = fmt.Errorf("ContextIsNil")
+	ErrContextIsNilError = errors.New("ContextIsNil")
 )
 
 type flow struct {
@@ -36,10 +36,10 @@ type DRR struct {
 // NewDRR creates a new DRR with indicated output channel.
 //
 // The outChan must be non-nil, otherwise NewDRR returns
-// ChannelIsNilError error.
+// ErrChannelIsNilError error.
 func NewDRR(outChan chan interface{}) (*DRR, error) {
 	if outChan == nil {
-		return nil, ChannelIsNilError
+		return nil, ErrChannelIsNilError
 	}
 	return &DRR{
 		outChan: outChan,
@@ -49,15 +49,15 @@ func NewDRR(outChan chan interface{}) (*DRR, error) {
 // Input registers a new ingress flow, that is a channel with
 // priority.
 //
-// Input returns ChannelIsNilError if input channel is nil.
+// Input returns ErrChannelIsNilError if input channel is nil.
 // Priority must be greater than 0, otherwise Input returns
-// InvalidPriorityValueError error.
+// ErrInvalidPriorityValueError error.
 func (d *DRR) Input(prio int, in <-chan interface{}) error {
 	if prio <= 0 {
-		return InvalidPriorityValueError
+		return ErrInvalidPriorityValueError
 	}
 	if in == nil {
-		return ChannelIsNilError
+		return ErrChannelIsNilError
 	}
 	d.flows = append(d.flows, flow{c: in, prio: prio})
 	return nil
@@ -73,7 +73,7 @@ func (d *DRR) Input(prio int, in <-chan interface{}) error {
 // channels are closed. DRR goroutine closes the output channel upon termination.
 func (d *DRR) Start(ctx context.Context) error {
 	if ctx == nil {
-		return ContextIsNilError
+		return ErrContextIsNilError
 	}
 	go func() {
 		defer close(d.outChan)

--- a/drr.go
+++ b/drr.go
@@ -9,15 +9,15 @@ import (
 )
 
 var (
-	// ErrInvalidPriorityValueError error is returned by Input method when
+	// ErrInvalidPriorityValue error is returned by Input method when
 	// priority value is less than or equal to 0.
-	ErrInvalidPriorityValueError = errors.New("ErrInvalidPriorityValueError")
-	// ErrChannelIsNilError error is returned by NewDRR and Input methods
+	ErrInvalidPriorityValue = errors.New("ErrInvalidPriorityValue")
+	// ErrChannelIsNil error is returned by NewDRR and Input methods
 	// when channel is nil.
-	ErrChannelIsNilError = errors.New("ErrChannelIsNilError")
-	// ErrContextIsNilError is returned by Start method when context.Context
+	ErrChannelIsNil = errors.New("ErrChannelIsNil")
+	// ErrContextIsNil is returned by Start method when context.Context
 	// is nil
-	ErrContextIsNilError = errors.New("ContextIsNil")
+	ErrContextIsNil = errors.New("ContextIsNil")
 )
 
 type flow struct {
@@ -36,10 +36,10 @@ type DRR struct {
 // NewDRR creates a new DRR with indicated output channel.
 //
 // The outChan must be non-nil, otherwise NewDRR returns
-// ErrChannelIsNilError error.
+// ErrChannelIsNil error.
 func NewDRR(outChan chan interface{}) (*DRR, error) {
 	if outChan == nil {
-		return nil, ErrChannelIsNilError
+		return nil, ErrChannelIsNil
 	}
 	return &DRR{
 		outChan: outChan,
@@ -49,15 +49,15 @@ func NewDRR(outChan chan interface{}) (*DRR, error) {
 // Input registers a new ingress flow, that is a channel with
 // priority.
 //
-// Input returns ErrChannelIsNilError if input channel is nil.
+// Input returns ErrChannelIsNil if input channel is nil.
 // Priority must be greater than 0, otherwise Input returns
-// ErrInvalidPriorityValueError error.
+// ErrInvalidPriorityValue error.
 func (d *DRR) Input(prio int, in <-chan interface{}) error {
 	if prio <= 0 {
-		return ErrInvalidPriorityValueError
+		return ErrInvalidPriorityValue
 	}
 	if in == nil {
-		return ErrChannelIsNilError
+		return ErrChannelIsNil
 	}
 	d.flows = append(d.flows, flow{c: in, prio: prio})
 	return nil
@@ -73,7 +73,7 @@ func (d *DRR) Input(prio int, in <-chan interface{}) error {
 // channels are closed. DRR goroutine closes the output channel upon termination.
 func (d *DRR) Start(ctx context.Context) error {
 	if ctx == nil {
-		return ErrContextIsNilError
+		return ErrContextIsNil
 	}
 	go func() {
 		defer close(d.outChan)

--- a/drr_test.go
+++ b/drr_test.go
@@ -111,7 +111,7 @@ func getFlowID(s string) int {
 	idStr := strings.Split(s, ":")[0]
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		panic(fmt.Errorf("convert of string %s failed: %v", s, err))
+		panic(fmt.Errorf("convert of string %s failed: %w", s, err))
 	}
 	return id
 }
@@ -164,19 +164,19 @@ func TestErrorInput(t *testing.T) {
 	Convey("Create DRR by passing nil output chan", t, func() {
 		drr, err := NewDRR(nil)
 		So(drr, ShouldEqual, nil)
-		So(err, ShouldEqual, ChannelIsNilError)
+		So(err, ShouldEqual, ErrChannelIsNilError)
 	})
 	Convey("Create DRR and pass wrong values in Input API", t, func() {
 		drr, _ := NewDRR(make(chan interface{}))
 		err := drr.Input(0, make(chan interface{}))
-		So(err, ShouldEqual, InvalidPriorityValueError)
+		So(err, ShouldEqual, ErrInvalidPriorityValueError)
 		err = drr.Input(1, nil)
-		So(err, ShouldEqual, ChannelIsNilError)
+		So(err, ShouldEqual, ErrChannelIsNilError)
 	})
 	Convey("Create DRR and pass wrong values in Input API", t, func() {
 		drr, _ := NewDRR(make(chan interface{}))
 		err := drr.Start(nil)
-		So(err, ShouldEqual, ContextIsNilError)
+		So(err, ShouldEqual, ErrContextIsNilError)
 	})
 }
 

--- a/drr_test.go
+++ b/drr_test.go
@@ -164,19 +164,19 @@ func TestErrorInput(t *testing.T) {
 	Convey("Create DRR by passing nil output chan", t, func() {
 		drr, err := NewDRR(nil)
 		So(drr, ShouldEqual, nil)
-		So(err, ShouldEqual, ErrChannelIsNilError)
+		So(err, ShouldEqual, ErrChannelIsNil)
 	})
 	Convey("Create DRR and pass wrong values in Input API", t, func() {
 		drr, _ := NewDRR(make(chan interface{}))
 		err := drr.Input(0, make(chan interface{}))
-		So(err, ShouldEqual, ErrInvalidPriorityValueError)
+		So(err, ShouldEqual, ErrInvalidPriorityValue)
 		err = drr.Input(1, nil)
-		So(err, ShouldEqual, ErrChannelIsNilError)
+		So(err, ShouldEqual, ErrChannelIsNil)
 	})
 	Convey("Create DRR and pass wrong values in Input API", t, func() {
 		drr, _ := NewDRR(make(chan interface{}))
 		err := drr.Start(nil)
-		So(err, ShouldEqual, ErrContextIsNilError)
+		So(err, ShouldEqual, ErrContextIsNil)
 	})
 }
 


### PR DESCRIPTION
These are basically lint fixes that I happened to find when I was playing around with this drr package.

o Prefer `Err..` for error variable names.
o Use `%w` during a `fmt.Errorf(..)` for `panic(..)`'s to get a wrapped
error.
o Use `errors.New(..)` in stdlib instead of `fmt.Errorf(..)`